### PR TITLE
Fix topbar support link

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -18,7 +18,7 @@
   "topbarLinks": [
     {
       "name": "Support",
-      "url": "support@trickle.so"
+      "url": "mailto:support@trickle.so"
     }
   ],
   "topbarCtaButton": {


### PR DESCRIPTION
## Summary
- use a valid `mailto:` link for the Support entry

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684bbd49ad2c8328a0cbacbd7f0fede3